### PR TITLE
loosen dependencies?

### DIFF
--- a/Strafunski-StrategyLib.cabal
+++ b/Strafunski-StrategyLib.cabal
@@ -52,8 +52,8 @@ library
 --   other-modules:       
 
   build-depends:
-        base ==4.5.*,
-        mtl ==2.1.*,
-        syb ==0.3.*,
-        directory ==1.2.*
+        base > 4.4,
+        mtl > 2.1,
+        syb > 0.3,
+        directory > 1.2
   


### PR DESCRIPTION
I couldn't compile with the strict dependencies, but these loosened ones worked fine.  I think this accords with the movement toward lower but not upper bounds.  I am using ghc-7.6 with these versions installed:
   base-4.6.0.1
   mtl-2.1.2
   syb-0.3.7
   directory-1.2.0.1
