### PR TITLE
Export TU constructor MkTU for external combinator construction.

### DIFF
--- a/Data/Generics/Strafunski/StrategyLib/Models/Deriving/StrategyPrimitives.hs
+++ b/Data/Generics/Strafunski/StrategyLib/Models/Deriving/StrategyPrimitives.hs
@@ -11,7 +11,7 @@ retained as is.
 module Data.Generics.Strafunski.StrategyLib.Models.Deriving.StrategyPrimitives (
 
   Term,
-  TP,         TU,
+  TP,         TU(..),
   paraTP,     paraTU,
   applyTP,    applyTU,
   adhocTP,    adhocTU,


### PR DESCRIPTION
I am using this library for manipulating the GHC AST, which has holes. I have created  a first-pass version of stop_tdTU and full_tdTU, but to do that I needed to use MkTU.

See https://github.com/alanz/HaRe/blob/e010f1a84df0675c894d6bcd95bc7f9cfe08173d/src/Language/Haskell/Refact/Utils/GhcUtils.hs#L297 

Is this the best way to dodge the holes?

What is the best way to manage the GHC-Specific combinators? I see three options
1. Leave it buried in the bowels of HaRe
2. Expose it in a hackage library on its own
3. Include it in Strafunski.
