### PR TITLE
relax base constraint for GHC 7.8

### DIFF
--- a/Strafunski-StrategyLib.cabal
+++ b/Strafunski-StrategyLib.cabal
@@ -52,7 +52,7 @@ library
 --   other-modules:       
 
   build-depends:
-        base > 4.4 && < 4.6.1,
+        base > 4.4 && < 4.8,
         mtl > 2.1 && < 2.2,
         syb > 0.3 && < 4.1,
         directory > 1.1 && < 1.2.1


### PR DESCRIPTION
GHC 7.8 comes with base-4.7.0.0.

Install with GHC 7.8 works with this change.
